### PR TITLE
RopeCreate compat

### DIFF
--- a/combined-items/rtcolumbiaitems/config.cpp
+++ b/combined-items/rtcolumbiaitems/config.cpp
@@ -84,6 +84,7 @@ class CfgMagazines
 
 class CfgVehicles 
 {
+    class Land_InvisibleBarrier_F;
     class Thing;
     class colsog_thing_handsid_sensor : Thing  
     {
@@ -123,5 +124,10 @@ class CfgVehicles
         scopecurator = 2;
         author = "Gerard";
         destrType = "DestructNo";
+    };
+    class colsog_Land_InvisibleBarrier_F : Land_InvisibleBarrier_F
+    {
+        displayName = "Rope Compat InvisibleBarrier";
+        simulation = "car";
     };
 };


### PR DESCRIPTION
This add the required simulation on Land_InvisibleBarrier_F to create rope

There is a popup the first time object "colsog_Land_InvisibleBarrier_F" is spawned, probably a missing entry for ACE as it's now considered a vehicle. Might be something unsolvable due to the simulation type.

Atm, only added displayName to differentiate in Eden. Might need to tweak access & scope so it only is accessible through script and not editor/zeus